### PR TITLE
[codex] Improve watcher reporting and add setup review

### DIFF
--- a/.github/workflows/review-agentic-setup.yml
+++ b/.github/workflows/review-agentic-setup.yml
@@ -1,0 +1,133 @@
+name: Claude Review Ontology Agentic Setup
+
+on:
+  schedule:
+    - cron: "47 14 * * 1"
+  workflow_dispatch:
+    inputs:
+      target_repos:
+        description: Optional comma-separated configured repos to include
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: claude-agentic-setup-review
+  cancel-in-progress: false
+
+jobs:
+  review-setup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install package
+        run: python -m pip install -e .
+
+      - name: Generate setup review context
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          WATCHER_SOURCE_TOKEN: ${{ secrets.WATCHER_SOURCE_TOKEN }}
+          TARGET_REPOS_INPUT: ${{ github.event_name == 'workflow_dispatch' && inputs.target_repos || '' }}
+        run: |
+          set -euo pipefail
+          mkdir -p build
+          args=(
+            --config config/targets.json
+            --output-dir build/setup-review
+          )
+          if [ -n "${TARGET_REPOS_INPUT}" ]; then
+            python3 - <<'PY' > build/setup-review-targets.txt
+          import os
+
+          raw = os.environ["TARGET_REPOS_INPUT"]
+          for part in raw.split(","):
+              cleaned = part.strip()
+              if cleaned:
+                  print(cleaned)
+          PY
+            while IFS= read -r repo; do
+              args+=(--target "${repo}")
+            done < build/setup-review-targets.txt
+          fi
+          python3 scripts/run_setup_review.py "${args[@]}"
+
+      - name: Upload setup review artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ontology-agentic-setup-review
+          path: build/setup-review
+
+      - name: Verify Claude credentials are configured
+        env:
+          HAS_ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY != '' && 'true' || 'false' }}
+          HAS_CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' && 'true' || 'false' }}
+        run: |
+          if [ "${HAS_ANTHROPIC_API_KEY}" != "true" ] && [ "${HAS_CLAUDE_CODE_OAUTH_TOKEN}" != "true" ]; then
+            echo "::error::Set either ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN for the Claude setup-review workflow."
+            exit 1
+          fi
+
+      - name: Ask Claude for cross-repo setup review
+        uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ github.token }}
+        with:
+          github_token: ${{ github.token }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            Review the ontology agentic setup across the selected watched repositories.
+
+            Start with the local summary file `@build/setup-review/summary.md`, then read the per-repo setup dossiers under `build/setup-review/*.md`.
+
+            Read `build/setup-review/metadata.json` to get the exact report date and issue title.
+
+            Your job is to maintain the dated watcher issue in `${{ github.repository }}` whose exact title is the `issue_title` value from `build/setup-review/metadata.json`.
+
+            Required workflow:
+            1. Read `build/setup-review/metadata.json`, `build/setup-review/summary.md`, and the per-repo markdown dossiers.
+            2. Use only those local files as evidence. Do not rely on live reads from the watched repos.
+            3. Find the issue in `${{ github.repository }}` by exact title from the metadata file. If it does not exist, create it with the labels `agent-watcher` and `report`. If it exists and is closed, reopen it.
+            4. Ensure the issue has the labels `agent-watcher` and `report`.
+            5. Replace the issue body with a concise cross-repo current-status summary for this review date.
+            6. Append a fuller comparative review comment.
+
+            The review should emphasize:
+            - whether each repo has sufficient central agent instructions
+            - whether recurring tasks appear partitioned into skills, commands, or subagents where appropriate
+            - whether the agent-related workflows look coherent and maintainable
+            - differences across repos and obvious outliers
+            - concrete best-practice recommendations, prioritized for the highest-leverage repos
+
+            Constraints:
+            - Do not assign a score or pass/fail label.
+            - Use full Markdown links when referring to watched repos or file paths outside `${{ github.repository }}`.
+            - Be concrete and compare repos explicitly.
+            - Keep the issue body concise and the appended comment practical.
+
+            Command guidance:
+            - Find the issue with `gh issue list --repo "${{ github.repository }}" --state all --search '<exact title from metadata> in:title' --json number,title,state`
+            - Create it with `gh issue create --repo "${{ github.repository }}" --label agent-watcher --label report`
+            - Update it with `gh issue edit --repo "${{ github.repository }}" --add-label agent-watcher --add-label report`
+            - Reopen it with `gh issue reopen --repo "${{ github.repository }}"`
+            - Append the full review with `gh issue comment --repo "${{ github.repository }}"`
+
+            You may create temporary markdown files under `build/claude/` before posting.
+          claude_args: |
+            --allowedTools "Bash(ls:*),Bash(cat:*),Bash(mkdir:*),Bash(gh issue list:*),Bash(gh issue create:*),Bash(gh issue edit:*),Bash(gh issue reopen:*),Bash(gh issue comment:*),Read,Write,Edit"
+
+      - name: Publish setup review summary
+        run: cat build/setup-review/summary.md >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/scan-watched-repos.yml
+++ b/.github/workflows/scan-watched-repos.yml
@@ -130,19 +130,29 @@ jobs:
             Required workflow:
             1. Read the local context file.
             2. Use that dossier as the evidence base for your review. Do not rely on live reads from `${{ matrix.repo }}`.
-            3. Find the issue in `${{ github.repository }}` by exact title `${{ matrix.issue_title }}`. If it does not exist, create it. If it exists and is closed, reopen it.
-            4. Replace the issue body with a concise current-status summary for this report date.
-            5. Append a fuller qualitative review comment for this report date.
+            3. Find the issue in `${{ github.repository }}` by exact title `${{ matrix.issue_title }}`. If it does not exist, create it with the labels `agent-watcher` and `report`. If it exists and is closed, reopen it.
+            4. Ensure the issue has the labels `agent-watcher` and `report`.
+            5. Replace the issue body with a concise current-status summary for this report date.
+            6. Append a fuller qualitative review comment for this report date.
 
             The review should emphasize:
             - what seems to be working
             - what seems not to be working
             - recurring failure modes or friction
             - light quantitative context only when useful, such as number of summons or number of agent-touched PRs/issues
+            - when agent activity is sparse or absent, whether the dossier shows missed opportunities: recent open issues that look like plausible low-friction starting points for an agent-authored PR
+
+            Opportunity guidance:
+            - Start with the `Potential Missed Opportunities` section when the repo has little or no agent activity.
+            - Recommend at most 3 candidates.
+            - Only recommend a candidate when the local dossier shows a concrete, bounded ask in the issue body or recent human comments.
+            - If the dossier does not support a confident recommendation, say that clearly instead of inventing one.
 
             Constraints:
             - Do not assign a score or labels like strong, mixed, needs_attention, or pass/fail.
             - Be concrete and cite issue/PR numbers.
+            - When referring to issues or PRs from `${{ matrix.repo }}`, do not use bare `#123` shorthand. Use full Markdown links to the watched repo items, for example `[issue #123](https://github.com/${{ matrix.repo }}/issues/123)` or `[PR #456](https://github.com/${{ matrix.repo }}/pull/456)`.
+            - Bare `#123` references are only acceptable for issues in `${{ github.repository }}` itself.
             - Keep the body concise and the appended comment substantial but practical.
             - Use Markdown headings and flat bullets only when they help readability.
             - The issue title must be exactly `${{ matrix.issue_title }}`.
@@ -152,8 +162,8 @@ jobs:
 
             Command guidance:
             - Find the issue with something like `gh issue list --repo "${{ github.repository }}" --state all --search '"${{ matrix.issue_title }}" in:title' --json number,title,state`
-            - Create it with `gh issue create --repo "${{ github.repository }}"`
-            - Update it with `gh issue edit --repo "${{ github.repository }}"`
+            - Create it with `gh issue create --repo "${{ github.repository }}" --label agent-watcher --label report`
+            - Update it with `gh issue edit --repo "${{ github.repository }}" --add-label agent-watcher --add-label report`
             - Reopen it with `gh issue reopen --repo "${{ github.repository }}"`
             - Append the full review with `gh issue comment --repo "${{ github.repository }}"`
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -66,11 +66,28 @@ jobs:
             --output-dir build/validate \
             --dry-run
 
+      - name: Dry-run setup review
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          WATCHER_SOURCE_TOKEN: ${{ secrets.WATCHER_SOURCE_TOKEN }}
+        run: |
+          set -euo pipefail
+          python scripts/run_setup_review.py \
+            --config config/targets.json \
+            --target geneontology/go-ontology \
+            --target obophenotype/cell-ontology \
+            --output-dir build/validate-setup-review
+
       - name: Upload validation artifact
         uses: actions/upload-artifact@v4
         with:
           name: watcher-validation-preview
-          path: build/validate
+          path: |
+            build/validate
+            build/validate-setup-review
 
       - name: Publish validation summary
-        run: cat build/validate/summary.md >> "${GITHUB_STEP_SUMMARY}"
+        run: |
+          cat build/validate/summary.md >> "${GITHUB_STEP_SUMMARY}"
+          printf '\n\n## Setup Review Preview\n\n' >> "${GITHUB_STEP_SUMMARY}"
+          cat build/validate-setup-review/summary.md >> "${GITHUB_STEP_SUMMARY}"

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The current shape is:
 - the collector produces neutral context, not a score
 - the scheduled workflow uses `anthropics/claude-code-action@v1`
 - Claude creates or updates one dated issue per watched repo and report date
+- a separate weekly workflow compares ontology repos together for agentic setup best practices
 
 ## Initial Scope
 
@@ -16,6 +17,7 @@ The current shape is:
 - Inspect recently updated issues and PRs in a lookback window
 - Detect agent involvement from author logins, comments, PR reviews, and common agent markers in text
 - Generate a context file per watched repo with lightweight counts and event timelines
+- Surface a small set of recent open non-agent issues as possible missed opportunities when agent activity is absent
 - Select only repos due for the current schedule slot based on config
 - Ask Claude to summarize what appears to be working, not working, and where the friction is
 - Publish findings back into this repo as dated issues such as `go-ontology report for 2026-03-31`
@@ -27,6 +29,7 @@ The current shape is:
 - [`scripts/run_watch.py`](/Users/cjm/repos/agent-watcher/scripts/run_watch.py): local and workflow entrypoint
 - [`src/agent_watcher`](/Users/cjm/repos/agent-watcher/src/agent_watcher): scanner and Markdown context generation code
 - [`.github/workflows/scan-watched-repos.yml`](/Users/cjm/repos/agent-watcher/.github/workflows/scan-watched-repos.yml): scheduled and manual Claude review workflow
+- [`.github/workflows/review-agentic-setup.yml`](/Users/cjm/repos/agent-watcher/.github/workflows/review-agentic-setup.yml): weekly cross-repo setup review workflow
 - [`.github/workflows/validate.yml`](/Users/cjm/repos/agent-watcher/.github/workflows/validate.yml): validation and dry-run workflow
 
 ## Local Usage
@@ -50,6 +53,15 @@ export WATCHER_SOURCE_TOKEN=ghp_xxx
 python3 scripts/run_watch.py \
   --config config/targets.json \
   --output-dir build/context
+```
+
+Collect weekly cross-repo setup-review context for the marked ontology repos:
+
+```bash
+export WATCHER_SOURCE_TOKEN=ghp_xxx
+python3 scripts/run_setup_review.py \
+  --config config/targets.json \
+  --output-dir build/setup-review
 ```
 
 ## Required Secrets
@@ -84,6 +96,7 @@ Each target can declare:
 - `preferred_weekday_utc`: `0` for Monday through `6` for Sunday
 - `preferred_hour_utc`
 - `issue_title_template`
+- `include_in_setup_review`: whether the repo participates in the weekly cross-repo setup review
 
 The selector script [`scripts/select_targets.py`](/Users/cjm/repos/agent-watcher/scripts/select_targets.py) reads that config and builds the matrix dynamically.
 
@@ -112,6 +125,8 @@ gh workflow run scan-watched-repos.yml \
   -f lookback_days=14 \
   -f max_items=25
 
+gh workflow run review-agentic-setup.yml
+
 gh workflow run validate.yml \
   -f target_repo=geneontology/go-ontology
 ```
@@ -119,4 +134,5 @@ gh workflow run validate.yml \
 ## Notes
 
 - The collector deliberately stays simple and deterministic; Claude is used for the actual qualitative judgment.
-- The context artifacts in `build/` are for debugging and for giving Claude enough evidence to write a useful review.
+- The context artifacts in `build/` are for debugging and for giving Claude enough evidence to write a useful review, including possible missed-opportunity tickets when no agent activity was detected.
+- Because reports are posted in this repository rather than the watched repo, cross-repo issue and PR references should be rendered as full Markdown links, not bare `#123` shorthand.

--- a/config/targets.json
+++ b/config/targets.json
@@ -8,6 +8,7 @@
     "issue_title_template": "{short_name} report for {report_date}",
     "cadence": "weekly",
     "preferred_hour_utc": 13,
+    "include_in_setup_review": true,
     "extra_prompt": "",
     "agent_login_substrings": [
       "dragon-ai-agent",

--- a/docs/design.md
+++ b/docs/design.md
@@ -4,6 +4,8 @@
 
 Run a scheduled watcher in GitHub Actions that inspects selected deployment repos, gathers recent issues and PRs involving agents, and asks Claude Code to write a practical qualitative assessment of what appears to be working or not working.
 
+In addition, run a weekly cross-repo review over the marked ontology repos that compares their agentic setup: instruction files, workflow conventions, and whether repeated work is decomposed into skills, commands, or subagents.
+
 ## Non-Goals For The First Pass
 
 - full conversational transcript analysis
@@ -33,6 +35,7 @@ The current architecture has four phases:
      - an author or commenter login matches configured agent substrings
      - a body, comment, or review contains agent markers such as `@dragon-ai-agent` or `Claude Code`
    - Produce a neutral Markdown dossier per watched repo
+   - When a recent open issue has no detected agent involvement, surface it as a possible missed opportunity for reviewer consideration
    - Include event timelines and lightweight supporting counts such as summons, merged PRs, and open items
    - Avoid making the final judgment in code
 
@@ -42,6 +45,7 @@ The current architecture has four phases:
    - Create or update one dated issue per watched repo and report date in this repository
    - Replace the issue body with a concise current-status summary
    - Append a dated comment per run with the fuller qualitative review
+   - Use full Markdown links for watched-repo issues and PRs because the published report lives in a separate repository
 
 ## Why Claude For The Final Review
 
@@ -95,6 +99,16 @@ neutral Markdown dossier
 - generates one context artifact per target
 - asks Claude to create or update the corresponding dated report issue in this repo
 - uploads the generated context artifacts
+
+### Weekly Setup Review Workflow
+
+[`.github/workflows/review-agentic-setup.yml`](/Users/cjm/repos/agent-watcher/.github/workflows/review-agentic-setup.yml)
+
+- runs weekly and on manual dispatch
+- collects setup context across all targets with `include_in_setup_review=true`
+- inspects repo-level instruction files, agent-related workflows, and detected skill/subagent directories
+- asks Claude to compare repos against one another and recommend best-practice improvements
+- creates or updates one dated cross-repo review issue in this repo with the `agent-watcher` label
 
 ### Validation Workflow
 
@@ -151,5 +165,5 @@ GitHub Actions then creates one job per row. Adding a new ontology means adding 
 - add repo-specific match rules where agents have distinct identities
 - add inline review comment collection for PR-heavy repos
 - persist run summaries as JSON history for trend charts
-- improve prompt guidance for repo-specific ontology expectations
+- improve prompt guidance for repo-specific ontology expectations and opportunity triage
 - tag noteworthy findings, such as repeated duplicate agent PRs or human rework after merge

--- a/scripts/run_setup_review.py
+++ b/scripts/run_setup_review.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from agent_watcher.github_api import GitHubClient
+from agent_watcher.setup_review import generate_setup_review_reports, write_setup_review_reports
+
+
+def main() -> int:
+    args = _parse_args()
+    source_token = os.getenv("WATCHER_SOURCE_TOKEN") or os.getenv("GITHUB_TOKEN")
+    client = GitHubClient(source_token)
+    only_repos = set(args.target) if args.target else None
+
+    reports = generate_setup_review_reports(client, args.config, only_repos=only_repos)
+    if not reports:
+        raise SystemExit("No setup-review targets matched the supplied configuration and filters.")
+
+    write_setup_review_reports(args.output_dir, reports)
+
+    print(f"Wrote {len(reports)} setup review report(s) to {Path(args.output_dir).resolve()}")
+    for report in reports:
+        print(
+            f"- {report.repo}: "
+            f"instructions={len(report.instruction_files)} "
+            f"assets={len(report.asset_directories)} "
+            f"agent_workflows={len(report.agent_workflows)} "
+            f"findings={len(report.findings)} "
+            f"errors={len(report.errors)}"
+        )
+    return 0
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Collect cross-repo agentic setup review context.")
+    parser.add_argument("--config", default="config/targets.json", help="Path to watcher config JSON.")
+    parser.add_argument("--output-dir", default="build/setup-review", help="Directory for markdown and JSON output.")
+    parser.add_argument(
+        "--target",
+        action="append",
+        default=None,
+        help="Include only selected configured repo(s); repeat the flag to add more repos.",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agent_watcher/config.py
+++ b/src/agent_watcher/config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 from .models import TargetRepo
 
@@ -49,6 +50,38 @@ def load_targets(
                     merged.get("agent_text_patterns", [])
                 ),
             )
+        )
+
+    return targets
+
+
+def load_setup_review_targets(
+    config_path: str | Path,
+    *,
+    only_repos: set[str] | None = None,
+) -> list[dict[str, Any]]:
+    path = Path(config_path)
+    payload = json.loads(path.read_text())
+    defaults = payload.get("defaults", {})
+    targets: list[dict[str, Any]] = []
+
+    for raw_target in payload.get("targets", []):
+        repo = raw_target["repo"]
+        if only_repos and repo not in only_repos:
+            continue
+
+        merged = {**defaults, **raw_target}
+        if not merged.get("include_in_setup_review", True):
+            continue
+
+        targets.append(
+            {
+                "repo": repo,
+                "display_name": merged.get("display_name", repo),
+                "short_name": merged.get("short_name", repo.split("/")[-1]),
+                "report_timezone": merged.get("report_timezone", "America/Los_Angeles"),
+                "extra_prompt": merged.get("extra_prompt", ""),
+            }
         )
 
     return targets

--- a/src/agent_watcher/github_api.py
+++ b/src/agent_watcher/github_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import json
 from typing import Any
 from urllib.error import HTTPError
@@ -68,6 +69,52 @@ class GitHubClient:
 
     def get_pr(self, repo: str, number: int) -> dict[str, Any]:
         return self._request_json("GET", f"/repos/{repo}/pulls/{number}")
+
+    def get_repo(self, repo: str) -> dict[str, Any]:
+        return self._request_json("GET", f"/repos/{repo}")
+
+    def list_directory_contents(
+        self,
+        repo: str,
+        path: str,
+        *,
+        ref: str | None = None,
+    ) -> list[dict[str, Any]] | None:
+        encoded_path = quote(path, safe="/")
+        suffix = f"?ref={quote(ref, safe='')}" if ref else ""
+        try:
+            payload = self._request_json("GET", f"/repos/{repo}/contents/{encoded_path}{suffix}")
+        except RuntimeError as exc:
+            if "404" in str(exc):
+                return None
+            raise
+        if isinstance(payload, list):
+            return payload
+        return None
+
+    def get_file_text(
+        self,
+        repo: str,
+        path: str,
+        *,
+        ref: str | None = None,
+    ) -> str | None:
+        encoded_path = quote(path, safe="/")
+        suffix = f"?ref={quote(ref, safe='')}" if ref else ""
+        try:
+            payload = self._request_json("GET", f"/repos/{repo}/contents/{encoded_path}{suffix}")
+        except RuntimeError as exc:
+            if "404" in str(exc):
+                return None
+            raise
+        if not isinstance(payload, dict) or payload.get("type") != "file":
+            return None
+        content = payload.get("content", "")
+        if not content:
+            return ""
+        if payload.get("encoding") == "base64":
+            return base64.b64decode(content).decode("utf-8", errors="replace")
+        return str(content)
 
     def find_issue_by_title(self, repo: str, title: str) -> dict[str, Any] | None:
         page = 1

--- a/src/agent_watcher/models.py
+++ b/src/agent_watcher/models.py
@@ -67,6 +67,7 @@ class RepoReport:
     issue_title: str
     recent_items_scanned: int
     tracked_items: list[TrackedItem] = field(default_factory=list)
+    opportunity_items: list[TrackedItem] = field(default_factory=list)
     metrics: dict[str, int] = field(default_factory=dict)
     errors: list[str] = field(default_factory=list)
 

--- a/src/agent_watcher/reporting.py
+++ b/src/agent_watcher/reporting.py
@@ -50,38 +50,22 @@ def render_report(report: RepoReport) -> str:
     lines.extend(["", "## Agent-Related Items", ""])
     if not report.tracked_items:
         lines.append("No agent-related items detected in this run.")
-        return "\n".join(lines) + "\n"
+    else:
+        for item in report.tracked_items:
+            lines.extend(_render_item(item, include_agent_fields=True, timeline_heading="#### Event Timeline"))
 
-    for item in report.tracked_items:
+    if report.opportunity_items:
         lines.extend(
             [
-                f"### {_item_link(item)}",
+                "## Potential Missed Opportunities",
                 "",
-                f"- Status: `{item.status}`",
-                f"- Author: `{item.author}`",
-                f"- Updated: `{item.updated_at.strftime('%Y-%m-%d %H:%M UTC')}`",
-                f"- Agent actors: {_csv_or_none(item.agent_actor_logins)}",
-                f"- Agent summons / references: `{item.agent_reference_hits}`",
-                f"- Latest actor: `{item.latest_actor}`",
-                f"- Signals: {escape_cell('; '.join(item.signals))}",
-                f"- Latest note excerpt: {escape_cell(item.latest_excerpt or '(none)')}",
-                "",
-                "#### Event Timeline",
+                "These are recent open issues with no detected agent involvement in the scan window.",
+                "They are candidate starting points for reviewer consideration, not automatic recommendations.",
                 "",
             ]
         )
-        for event in item.events:
-            markers: list[str] = []
-            if event.agent_actor:
-                markers.append("agent actor")
-            if event.agent_reference:
-                markers.append("agent reference")
-            marker_suffix = f" [{', '.join(markers)}]" if markers else ""
-            lines.append(
-                f"- `{event.created_at.strftime('%Y-%m-%d %H:%M UTC')}` "
-                f"`{event.kind}` by `{event.actor}`{marker_suffix}: {escape_cell(_excerpt(event.body))}"
-            )
-        lines.append("")
+        for item in report.opportunity_items:
+            lines.extend(_render_item(item, include_agent_fields=False, timeline_heading="#### Recent Activity"))
 
     return "\n".join(lines) + "\n"
 
@@ -131,6 +115,44 @@ def _excerpt(text: str, *, limit: int = 180) -> str:
     if len(cleaned) <= limit:
         return cleaned
     return cleaned[: limit - 3] + "..."
+
+
+def _render_item(
+    item: TrackedItem,
+    *,
+    include_agent_fields: bool,
+    timeline_heading: str,
+) -> list[str]:
+    lines = [
+        f"### {_item_link(item)}",
+        "",
+        f"- Status: `{item.status}`",
+        f"- Author: `{item.author}`",
+        f"- Updated: `{item.updated_at.strftime('%Y-%m-%d %H:%M UTC')}`",
+        f"- Latest actor: `{item.latest_actor}`",
+        f"- Signals: {escape_cell('; '.join(item.signals))}",
+        f"- Latest note excerpt: {escape_cell(item.latest_excerpt or '(none)')}",
+    ]
+    if include_agent_fields:
+        lines.insert(4, f"- Agent actors: {_csv_or_none(item.agent_actor_logins)}")
+        lines.insert(5, f"- Agent summons / references: `{item.agent_reference_hits}`")
+    else:
+        lines.append("- Why surfaced: recent open issue with no detected agent involvement")
+
+    lines.extend(["", timeline_heading, ""])
+    for event in item.events:
+        markers: list[str] = []
+        if event.agent_actor:
+            markers.append("agent actor")
+        if event.agent_reference:
+            markers.append("agent reference")
+        marker_suffix = f" [{', '.join(markers)}]" if markers else ""
+        lines.append(
+            f"- `{event.created_at.strftime('%Y-%m-%d %H:%M UTC')}` "
+            f"`{event.kind}` by `{event.actor}`{marker_suffix}: {escape_cell(_excerpt(event.body))}"
+        )
+    lines.append("")
+    return lines
 
 
 def _json(report: RepoReport) -> str:

--- a/src/agent_watcher/setup_review.py
+++ b/src/agent_watcher/setup_review.py
@@ -1,0 +1,359 @@
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+from zoneinfo import ZoneInfo
+
+from .config import load_setup_review_targets
+from .github_api import GitHubClient
+from .scheduling import repo_slug
+
+PRIMARY_INSTRUCTION_PATHS = (
+    "CLAUDE.md",
+    "AGENTS.md",
+    ".github/copilot-instructions.md",
+)
+ASSET_DIRECTORY_KINDS = (
+    (".claude/agents", "subagents"),
+    (".codex/agents", "subagents"),
+    (".github/agents", "subagents"),
+    (".codex/skills", "skills"),
+    (".github/skills", "skills"),
+    ("skills", "skills"),
+    (".claude/commands", "commands"),
+)
+AGENT_WORKFLOW_KEYWORDS = (
+    "claude",
+    "copilot",
+    "codex",
+    "dragon-ai-agent",
+    "openhands",
+    "swe-agent",
+)
+MAX_EXCERPT_LINES = 12
+
+
+@dataclass(frozen=True)
+class SetupInstructionFile:
+    path: str
+    excerpt: str
+
+
+@dataclass(frozen=True)
+class SetupAssetDirectory:
+    path: str
+    kind: str
+    entry_count: int
+    sample_entries: list[str]
+
+
+@dataclass(frozen=True)
+class SetupWorkflowFile:
+    path: str
+    name: str
+    agent_signals: list[str]
+
+
+@dataclass
+class SetupRepoReport:
+    repo: str
+    display_name: str
+    short_name: str
+    report_date: str
+    default_branch: str
+    generated_at: datetime
+    instruction_files: list[SetupInstructionFile] = field(default_factory=list)
+    asset_directories: list[SetupAssetDirectory] = field(default_factory=list)
+    agent_workflows: list[SetupWorkflowFile] = field(default_factory=list)
+    findings: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+    extra_prompt: str = ""
+
+    def to_dict(self) -> dict:
+        return _serialize(asdict(self))
+
+
+def generate_setup_review_reports(
+    client: GitHubClient,
+    config_path: str | Path,
+    *,
+    generated_at: datetime | None = None,
+    only_repos: set[str] | None = None,
+) -> list[SetupRepoReport]:
+    generated_at = generated_at or datetime.now(timezone.utc)
+    targets = load_setup_review_targets(config_path, only_repos=only_repos)
+    reports = [_collect_repo_setup(client, target, generated_at=generated_at) for target in targets]
+    reports.sort(key=lambda report: report.repo)
+    return reports
+
+
+def write_setup_review_reports(output_dir: str | Path, reports: list[SetupRepoReport]) -> None:
+    base = Path(output_dir)
+    base.mkdir(parents=True, exist_ok=True)
+
+    for report in reports:
+        slug = repo_slug(report.repo)
+        (base / f"{slug}.md").write_text(render_setup_review_report(report))
+        (base / f"{slug}.json").write_text(json.dumps(report.to_dict(), indent=2, sort_keys=True) + "\n")
+
+    metadata = {
+        "report_date": reports[0].report_date if reports else datetime.now(timezone.utc).date().isoformat(),
+        "issue_title": (
+            f"ontology agentic setup review for {reports[0].report_date}"
+            if reports
+            else f"ontology agentic setup review for {datetime.now(timezone.utc).date().isoformat()}"
+        ),
+        "repos": [report.repo for report in reports],
+    }
+    (base / "summary.md").write_text(render_setup_review_summary(reports))
+    (base / "metadata.json").write_text(json.dumps(metadata, indent=2, sort_keys=True) + "\n")
+
+
+def render_setup_review_report(report: SetupRepoReport) -> str:
+    lines = [
+        f"# Agentic Setup Context: {report.display_name}",
+        "",
+        f"- Repo: `{report.repo}`",
+        f"- Default branch: `{report.default_branch}`",
+        f"- Generated: `{report.generated_at.isoformat()}`",
+        f"- Report date: `{report.report_date}`",
+        f"- Instruction files found: `{len(report.instruction_files)}`",
+        f"- Instruction asset directories found: `{len(report.asset_directories)}`",
+        f"- Agent-related workflows found: `{len(report.agent_workflows)}`",
+    ]
+
+    if report.errors:
+        lines.extend(["", "## Errors", ""])
+        for error in report.errors:
+            lines.append(f"- {error}")
+
+    lines.extend(["", "## Findings", ""])
+    if report.findings:
+        for finding in report.findings:
+            lines.append(f"- {finding}")
+    else:
+        lines.append("- No obvious setup gaps detected from the collected signals.")
+
+    lines.extend(["", "## Instruction Files", ""])
+    if report.instruction_files:
+        for item in report.instruction_files:
+            lines.extend(
+                [
+                    f"### `{item.path}`",
+                    "",
+                    "```text",
+                    item.excerpt,
+                    "```",
+                    "",
+                ]
+            )
+    else:
+        lines.append("No primary instruction files were detected.")
+
+    lines.extend(["## Instruction Assets", ""])
+    if report.asset_directories:
+        for item in report.asset_directories:
+            sample = ", ".join(f"`{name}`" for name in item.sample_entries) if item.sample_entries else "(none)"
+            lines.extend(
+                [
+                    f"- `{item.path}` ({item.kind})",
+                    f"  entries: `{item.entry_count}`",
+                    f"  sample: {sample}",
+                ]
+            )
+    else:
+        lines.append("No subagent, skill, or command directories were detected.")
+
+    lines.extend(["", "## Agent Workflows", ""])
+    if report.agent_workflows:
+        for workflow in report.agent_workflows:
+            signal_text = ", ".join(f"`{signal}`" for signal in workflow.agent_signals)
+            lines.append(f"- `{workflow.path}` ({workflow.name}) -> {signal_text}")
+    else:
+        lines.append("No agent-related workflow files were detected.")
+
+    if report.extra_prompt:
+        lines.extend(["", "## Repo-Specific Guidance", "", report.extra_prompt])
+
+    return "\n".join(lines) + "\n"
+
+
+def render_setup_review_summary(reports: list[SetupRepoReport]) -> str:
+    lines = [
+        "# Ontology Agentic Setup Summary",
+        "",
+        "| Repo | Instructions | Subagents | Skills/Commands | Agent Workflows | Findings |",
+        "| --- | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for report in reports:
+        subagents = _count_assets(report.asset_directories, "subagents")
+        skills_commands = _count_assets(report.asset_directories, "skills") + _count_assets(
+            report.asset_directories, "commands"
+        )
+        lines.append(
+            "| "
+            f"`{report.repo}` | "
+            f"{len(report.instruction_files)} | "
+            f"{subagents} | "
+            f"{skills_commands} | "
+            f"{len(report.agent_workflows)} | "
+            f"{len(report.findings)} |"
+        )
+
+    missing_instructions = [f"`{report.repo}`" for report in reports if not report.instruction_files]
+    missing_decomposition = [
+        f"`{report.repo}`"
+        for report in reports
+        if report.instruction_files and not _count_assets(report.asset_directories, "subagents")
+        and not _count_assets(report.asset_directories, "skills")
+        and not _count_assets(report.asset_directories, "commands")
+    ]
+    with_subagents = [
+        f"`{report.repo}`" for report in reports if _count_assets(report.asset_directories, "subagents")
+    ]
+
+    lines.extend(["", "## Cross-Repo Comparison Notes", ""])
+    if missing_instructions:
+        lines.append(f"- No primary agent instruction file detected: {', '.join(missing_instructions)}")
+    if missing_decomposition:
+        lines.append(
+            f"- Has a primary instruction file but no obvious skill/subagent decomposition: {', '.join(missing_decomposition)}"
+        )
+    if with_subagents:
+        lines.append(f"- Repos with explicit subagent directories: {', '.join(with_subagents)}")
+    if not any([missing_instructions, missing_decomposition, with_subagents]):
+        lines.append("- Cross-repo structure looks broadly uniform from the collected signals.")
+
+    return "\n".join(lines) + "\n"
+
+
+def _collect_repo_setup(client: GitHubClient, target: dict, *, generated_at: datetime) -> SetupRepoReport:
+    report = SetupRepoReport(
+        repo=target["repo"],
+        display_name=target["display_name"],
+        short_name=target["short_name"],
+        report_date=generated_at.astimezone(ZoneInfo(target["report_timezone"])).date().isoformat(),
+        default_branch="unknown",
+        generated_at=generated_at,
+        extra_prompt=target.get("extra_prompt", ""),
+    )
+
+    try:
+        repo_info = client.get_repo(report.repo)
+        report.default_branch = repo_info.get("default_branch") or "unknown"
+
+        for path in PRIMARY_INSTRUCTION_PATHS:
+            text = client.get_file_text(report.repo, path, ref=report.default_branch)
+            if text is not None:
+                report.instruction_files.append(
+                    SetupInstructionFile(path=path, excerpt=_excerpt_lines(text, limit=MAX_EXCERPT_LINES))
+                )
+
+        for path, kind in ASSET_DIRECTORY_KINDS:
+            contents = client.list_directory_contents(report.repo, path, ref=report.default_branch)
+            if not contents:
+                continue
+            sample_entries = [item.get("name", "") for item in contents[:5] if item.get("name")]
+            report.asset_directories.append(
+                SetupAssetDirectory(
+                    path=path,
+                    kind=kind,
+                    entry_count=len(contents),
+                    sample_entries=sample_entries,
+                )
+            )
+
+        workflow_entries = client.list_directory_contents(report.repo, ".github/workflows", ref=report.default_branch) or []
+        for item in workflow_entries:
+            path = item.get("path", "")
+            if item.get("type") != "file" or not path.endswith((".yml", ".yaml")):
+                continue
+            text = client.get_file_text(report.repo, path, ref=report.default_branch) or ""
+            signals = _detect_agent_workflow_signals(text)
+            if signals:
+                report.agent_workflows.append(
+                    SetupWorkflowFile(
+                        path=path,
+                        name=_extract_workflow_name(text) or item.get("name", path),
+                        agent_signals=signals,
+                    )
+                )
+    except Exception as exc:  # pragma: no cover - network/operational safety
+        report.errors.append(str(exc))
+
+    report.findings = _build_setup_findings(report)
+    return report
+
+
+def _build_setup_findings(report: SetupRepoReport) -> list[str]:
+    findings: list[str] = []
+    instruction_paths = {item.path for item in report.instruction_files}
+    asset_kinds = {item.kind for item in report.asset_directories}
+
+    if not report.instruction_files:
+        findings.append("No primary agent instruction file detected (`CLAUDE.md`, `AGENTS.md`, or `.github/copilot-instructions.md`).")
+    elif instruction_paths == {".github/copilot-instructions.md"}:
+        findings.append("Only Copilot instructions were detected; there is no obvious repo-wide CLAUDE/AGENTS instruction file.")
+
+    if len(report.instruction_files) > 1:
+        findings.append("Multiple primary instruction files are present; check them for drift and overlapping guidance.")
+
+    if report.instruction_files and "subagents" not in asset_kinds and "skills" not in asset_kinds and "commands" not in asset_kinds:
+        findings.append("Has a primary instruction file but no obvious skill, command, or subagent decomposition.")
+
+    if ("subagents" in asset_kinds or "skills" in asset_kinds or "commands" in asset_kinds) and not report.instruction_files:
+        findings.append("Has decomposed agent assets but no obvious top-level instruction file tying them together.")
+
+    if not report.agent_workflows:
+        findings.append("No agent-related workflows were detected in `.github/workflows`.")
+
+    return findings
+
+
+def _detect_agent_workflow_signals(text: str) -> list[str]:
+    lowered = text.lower()
+    signals: list[str] = []
+    for keyword in AGENT_WORKFLOW_KEYWORDS:
+        if keyword in lowered:
+            signals.append(keyword)
+    action_uses = re.findall(r"uses:\s*([^\s]+)", text)
+    for action in action_uses:
+        lowered_action = action.lower()
+        if any(keyword in lowered_action for keyword in AGENT_WORKFLOW_KEYWORDS):
+            signals.append(action)
+    deduped: list[str] = []
+    for signal in signals:
+        if signal not in deduped:
+            deduped.append(signal)
+    return deduped
+
+
+def _extract_workflow_name(text: str) -> str | None:
+    match = re.search(r"^name:\s*(.+)$", text, re.MULTILINE)
+    if not match:
+        return None
+    return match.group(1).strip().strip("'\"")
+
+
+def _excerpt_lines(text: str, *, limit: int) -> str:
+    lines = [line.rstrip() for line in text.splitlines()]
+    trimmed = [line for line in lines if line.strip()][:limit]
+    return "\n".join(trimmed) if trimmed else "(file is empty)"
+
+
+def _count_assets(items: Iterable[SetupAssetDirectory], kind: str) -> int:
+    return sum(item.entry_count for item in items if item.kind == kind)
+
+
+def _serialize(value):
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, list):
+        return [_serialize(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _serialize(item) for key, item in value.items()}
+    return value

--- a/src/agent_watcher/watcher.py
+++ b/src/agent_watcher/watcher.py
@@ -7,6 +7,8 @@ from .github_api import GitHubClient
 from .models import Event, RepoReport, TargetRepo, TrackedItem
 from .scheduling import build_target_run_metadata
 
+MAX_OPPORTUNITY_ITEMS = 5
+
 
 def scan_target(client: GitHubClient, target: TargetRepo, *, generated_at: datetime) -> RepoReport:
     window_start = generated_at - timedelta(days=target.lookback_days)
@@ -29,13 +31,18 @@ def scan_target(client: GitHubClient, target: TargetRepo, *, generated_at: datet
         report.recent_items_scanned = len(items)
 
         tracked_items: list[TrackedItem] = []
+        opportunity_items: list[TrackedItem] = []
         for item in items:
-            tracked = _scan_item(client, target, item)
-            if tracked is not None:
-                tracked_items.append(tracked)
+            scanned = _scan_item(client, target, item)
+            if _has_agent_activity(scanned):
+                tracked_items.append(scanned)
+            elif _is_opportunity_candidate(scanned):
+                opportunity_items.append(scanned)
 
         tracked_items.sort(key=lambda item: item.updated_at, reverse=True)
+        opportunity_items.sort(key=lambda item: item.updated_at, reverse=True)
         report.tracked_items = tracked_items
+        report.opportunity_items = opportunity_items[:MAX_OPPORTUNITY_ITEMS]
     except Exception as exc:  # pragma: no cover - operational safety
         report.errors.append(str(exc))
 
@@ -47,7 +54,7 @@ def _scan_item(
     client: GitHubClient,
     target: TargetRepo,
     item: dict,
-) -> TrackedItem | None:
+) -> TrackedItem:
     number = int(item["number"])
     title = item.get("title", "")
     url = item.get("html_url", "")
@@ -108,8 +115,6 @@ def _scan_item(
             )
 
     events.sort(key=lambda event: event.created_at)
-    if not any(event.agent_actor or event.agent_reference for event in events):
-        return None
 
     latest_event = events[-1]
     author_is_agent = _matches_actor(author, target.agent_login_substrings)
@@ -193,6 +198,7 @@ def _build_metrics(report: RepoReport) -> dict[str, int]:
             1 for item in tracked if not item.agent_actor_logins and item.agent_reference_hits > 0
         ),
         "agent_authored_items": sum(1 for item in tracked if item.author_is_agent),
+        "potential_opportunities": len(report.opportunity_items),
         "errors": len(report.errors),
     }
 
@@ -205,6 +211,8 @@ def _build_item_signals(item: TrackedItem) -> list[str]:
     elif item.agent_actor_logins:
         logins = ", ".join(f"`{login}`" for login in item.agent_actor_logins)
         signals.append(f"agent activity from {logins}")
+    else:
+        signals.append("no agent involvement detected")
 
     if item.agent_reference_hits:
         signals.append(f"{item.agent_reference_hits} agent mention(s)")
@@ -218,6 +226,18 @@ def _build_item_signals(item: TrackedItem) -> list[str]:
         signals.append("waiting on human response")
 
     return signals
+
+
+def _has_agent_activity(item: TrackedItem) -> bool:
+    return item.author_is_agent or bool(item.agent_actor_logins) or item.agent_reference_hits > 0
+
+
+def _is_opportunity_candidate(item: TrackedItem) -> bool:
+    if item.kind != "issue" or item.status != "open":
+        return False
+    if _has_agent_activity(item):
+        return False
+    return not _is_bot_actor(item.latest_actor)
 
 
 def _matches_actor(actor: str, fragments: Iterable[str]) -> bool:

--- a/tests/test_setup_review.py
+++ b/tests/test_setup_review.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from agent_watcher.setup_review import generate_setup_review_reports, render_setup_review_summary
+
+
+class FakeGitHubClient:
+    def __init__(self, repo_info, files=None, directories=None):
+        self.repo_info = repo_info
+        self.files = files or {}
+        self.directories = directories or {}
+
+    def get_repo(self, repo):
+        return self.repo_info[repo]
+
+    def get_file_text(self, repo, path, *, ref=None):
+        return self.files.get((repo, path))
+
+    def list_directory_contents(self, repo, path, *, ref=None):
+        return self.directories.get((repo, path))
+
+
+class SetupReviewTests(TestCase):
+    def test_collects_setup_signals_and_summary(self):
+        config = {
+            "defaults": {
+                "report_timezone": "America/Los_Angeles",
+                "include_in_setup_review": True,
+            },
+            "targets": [
+                {
+                    "repo": "example/ontology",
+                    "display_name": "Example Ontology",
+                    "short_name": "example-ontology",
+                }
+            ],
+        }
+        client = FakeGitHubClient(
+            repo_info={"example/ontology": {"default_branch": "main"}},
+            files={
+                ("example/ontology", "CLAUDE.md"): "# Agent instructions\n\nPrefer narrow subagents.",
+                (
+                    "example/ontology",
+                    ".github/workflows/agent-review.yml",
+                ): "name: Agent Review\non: push\njobs:\n  review:\n    steps:\n      - uses: anthropics/claude-code-action@v1\n",
+            },
+            directories={
+                ("example/ontology", ".claude/agents"): [
+                    {"name": "curation.md", "path": ".claude/agents/curation.md", "type": "file"}
+                ],
+                ("example/ontology", ".github/workflows"): [
+                    {
+                        "name": "agent-review.yml",
+                        "path": ".github/workflows/agent-review.yml",
+                        "type": "file",
+                    }
+                ],
+            },
+        )
+
+        with TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "targets.json"
+            config_path.write_text(json.dumps(config))
+            reports = generate_setup_review_reports(
+                client,
+                config_path,
+                generated_at=datetime(2026, 4, 7, 15, 0, tzinfo=timezone.utc),
+            )
+
+        self.assertEqual(len(reports), 1)
+        report = reports[0]
+        self.assertEqual(report.default_branch, "main")
+        self.assertEqual(len(report.instruction_files), 1)
+        self.assertEqual(len(report.asset_directories), 1)
+        self.assertEqual(len(report.agent_workflows), 1)
+        self.assertIn("anthropics/claude-code-action@v1", report.agent_workflows[0].agent_signals)
+        self.assertIn("`example/ontology`", render_setup_review_summary(reports))
+
+    def test_flags_missing_instruction_file(self):
+        config = {
+            "defaults": {"report_timezone": "America/Los_Angeles"},
+            "targets": [{"repo": "example/no-instructions", "display_name": "No Instructions", "short_name": "no-instructions"}],
+        }
+        client = FakeGitHubClient(
+            repo_info={"example/no-instructions": {"default_branch": "main"}},
+            directories={("example/no-instructions", ".github/workflows"): []},
+        )
+
+        with TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "targets.json"
+            config_path.write_text(json.dumps(config))
+            reports = generate_setup_review_reports(
+                client,
+                config_path,
+                generated_at=datetime(2026, 4, 7, 15, 0, tzinfo=timezone.utc),
+            )
+
+        self.assertIn("No primary agent instruction file detected", reports[0].findings[0])

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -128,6 +128,47 @@ class WatcherTests(TestCase):
         self.assertIn("Agent summons / references", rendered)
         self.assertIn("Suggested issue title", rendered)
 
+    def test_surfaces_recent_open_non_agent_issues_as_potential_opportunities(self):
+        client = FakeGitHubClient(
+            items=[
+                {
+                    "number": 301,
+                    "title": "Add missing xref to mature cell term",
+                    "html_url": "https://github.com/example/repo/issues/301",
+                    "state": "open",
+                    "created_at": "2026-03-29T08:00:00Z",
+                    "updated_at": "2026-03-29T12:00:00Z",
+                    "body": "This should be a narrow ontology edit with a straightforward PR.",
+                    "user": {"login": "curator-1"},
+                },
+                {
+                    "number": 302,
+                    "title": "Discussion: longer term roadmap",
+                    "html_url": "https://github.com/example/repo/issues/302",
+                    "state": "closed",
+                    "created_at": "2026-03-29T08:00:00Z",
+                    "updated_at": "2026-03-29T12:00:00Z",
+                    "body": "Not open, so not an opportunity.",
+                    "user": {"login": "curator-2"},
+                },
+            ],
+            comments={
+                301: [
+                    _comment("curator-1", "2026-03-29T12:00:00Z", "Likely a quick follow-up if someone picks it up."),
+                ],
+            },
+        )
+
+        report = scan_target(client, TARGET, generated_at=_dt("2026-03-30T00:00:00Z"))
+        rendered = render_report(report)
+
+        self.assertEqual(report.metrics["agent_items"], 0)
+        self.assertEqual(report.metrics["potential_opportunities"], 1)
+        self.assertEqual(len(report.opportunity_items), 1)
+        self.assertIn("## Potential Missed Opportunities", rendered)
+        self.assertIn("Why surfaced: recent open issue with no detected agent involvement", rendered)
+        self.assertIn("Add missing xref to mature cell term", rendered)
+
 
 def _comment(login: str, created_at: str, body: str) -> dict:
     return {


### PR DESCRIPTION
## Summary
- improve watcher report generation with missed-opportunity context and stricter cross-repo issue-link instructions
- auto-apply `agent-watcher` and `report` labels to report issues, and add a new weekly cross-repo ontology setup review workflow
- add a setup-review collector plus validation coverage for instruction files, agent workflows, and subagent/skill decomposition

## What changed
- update the per-repo watcher prompt so reports use full watched-repo URLs instead of bare `#123` references
- extend the collector to surface recent open non-agent issues as `Potential Missed Opportunities`
- add `scripts/run_setup_review.py` and `src/agent_watcher/setup_review.py` for weekly cross-repo setup analysis
- add `.github/workflows/review-agentic-setup.yml`
- update `validate.yml` to dry-run the new setup-review path
- ensure future watcher/setup-review issues are created and maintained with `agent-watcher` and `report` labels

## Validation
- `python3 -m unittest discover -s tests -p 'test_*.py'`
- `python3 -m compileall src scripts tests`
- `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].sort.each { |f| YAML.load_file(f); puts "validated #{f}" }'`
- `python3 scripts/run_watch.py --config config/targets.json --target obophenotype/cell-ontology --lookback-days 14 --max-items 12 --output-dir build/cell-ontology-opportunities --dry-run`
- `python3 scripts/run_setup_review.py --config config/targets.json --output-dir build/live-setup-review`

## Notes
- the historical dated watcher issues were already backfilled with the `report` label directly on GitHub before this PR
- GitHub indicates the canonical repo location is now `ai4curation/agent-watcher`
