### PR TITLE
Simplify watcher cron target selection

### DIFF
--- a/.github/workflows/scan-watched-repos.yml
+++ b/.github/workflows/scan-watched-repos.yml
@@ -61,6 +61,7 @@ jobs:
     timeout-minutes: 25
     strategy:
       fail-fast: false
+      max-parallel: 2
       matrix: ${{ fromJSON(needs.select-targets.outputs.matrix) }}
 
     steps:

--- a/README.md
+++ b/README.md
@@ -87,18 +87,17 @@ This keeps reports easy to scan historically while still allowing reruns to upda
 
 ## How Scheduling Works
 
-The workflow is still a single YAML file. Staggering happens in [`config/targets.json`](/Users/cjm/repos/agent-watcher/config/targets.json), not by cloning workflows.
+The workflow is still a single YAML file. GitHub cron is the real schedule, and [`config/targets.json`](/Users/cjm/repos/agent-watcher/config/targets.json) only decides which repos participate on a given day.
 
 Each target can declare:
 
 - `short_name`
 - `cadence`: `weekly`, `daily`, or `manual`
 - `preferred_weekday_utc`: `0` for Monday through `6` for Sunday
-- `preferred_hour_utc`
 - `issue_title_template`
 - `include_in_setup_review`: whether the repo participates in the weekly cross-repo setup review
 
-The selector script [`scripts/select_targets.py`](/Users/cjm/repos/agent-watcher/scripts/select_targets.py) reads that config and builds the matrix dynamically.
+The selector script [`scripts/select_targets.py`](/Users/cjm/repos/agent-watcher/scripts/select_targets.py) reads that config and builds the matrix dynamically. Weekly repos are staggered by weekday, while the actual clock time comes from the workflow cron in [`.github/workflows/scan-watched-repos.yml`](/Users/cjm/repos/agent-watcher/.github/workflows/scan-watched-repos.yml). The review job still fans out per repo with a bounded matrix, so we avoid one large monolithic run without relying on a second scheduler in Python.
 
 ## Adding A Repo
 

--- a/config/targets.json
+++ b/config/targets.json
@@ -7,7 +7,6 @@
     "issue_mode": "dated",
     "issue_title_template": "{short_name} report for {report_date}",
     "cadence": "weekly",
-    "preferred_hour_utc": 13,
     "include_in_setup_review": true,
     "extra_prompt": "",
     "agent_login_substrings": [

--- a/docs/design.md
+++ b/docs/design.md
@@ -20,7 +20,7 @@ The current architecture has four phases:
 1. `Select`
    - Load watched repos from [`config/targets.json`](/Users/cjm/repos/agent-watcher/config/targets.json)
    - Merge defaults with repo-specific overrides
-   - Compute which repos are due for the current schedule slot based on cadence, preferred weekday, and preferred hour
+   - Compute which repos are due for the current schedule slot based on cadence and preferred weekday
    - Compute deterministic report metadata including `report_date` and exact issue title
    - Allow workflow or local CLI overrides for single-target runs and collection window
 

--- a/src/agent_watcher/config.py
+++ b/src/agent_watcher/config.py
@@ -41,7 +41,6 @@ def load_targets(
                 ),
                 cadence=merged.get("cadence", "weekly"),
                 preferred_weekday_utc=_optional_int(merged.get("preferred_weekday_utc")),
-                preferred_hour_utc=_optional_int(merged.get("preferred_hour_utc")),
                 extra_prompt=merged.get("extra_prompt", ""),
                 agent_login_substrings=_normalize_strings(
                     merged.get("agent_login_substrings", [])

--- a/src/agent_watcher/models.py
+++ b/src/agent_watcher/models.py
@@ -18,7 +18,6 @@ class TargetRepo:
     issue_title_template: str
     cadence: str
     preferred_weekday_utc: int | None
-    preferred_hour_utc: int | None
     extra_prompt: str
     agent_login_substrings: tuple[str, ...]
     agent_text_patterns: tuple[str, ...]

--- a/src/agent_watcher/scheduling.py
+++ b/src/agent_watcher/scheduling.py
@@ -29,9 +29,6 @@ def build_target_run_metadata(target: TargetRepo, now_utc: datetime) -> TargetRu
 def target_is_due(target: TargetRepo, now_utc: datetime) -> bool:
     now_utc = now_utc.astimezone(timezone.utc)
 
-    if target.preferred_hour_utc is not None and now_utc.hour != target.preferred_hour_utc:
-        return False
-
     cadence = target.cadence.lower()
     if cadence == "daily":
         return True

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -28,7 +28,6 @@ def _target(**overrides) -> TargetRepo:
         "issue_title_template": "{short_name} report for {report_date}",
         "cadence": "weekly",
         "preferred_weekday_utc": 0,
-        "preferred_hour_utc": 13,
         "extra_prompt": "",
         "agent_login_substrings": ("dragon-ai-agent",),
         "agent_text_patterns": ("@dragon-ai-agent",),
@@ -44,17 +43,18 @@ class SchedulingTests(TestCase):
         self.assertEqual(metadata.report_date, "2026-03-30")
         self.assertEqual(metadata.issue_title, "go-ontology report for 2026-03-30")
 
-    def test_weekly_target_due_only_on_matching_weekday_and_hour(self):
-        target = _target(preferred_weekday_utc=0, preferred_hour_utc=13)
+    def test_weekly_target_due_only_on_matching_weekday(self):
+        target = _target(preferred_weekday_utc=0)
         self.assertTrue(target_is_due(target, _dt("2026-03-30T13:17:00Z")))
         self.assertFalse(target_is_due(target, _dt("2026-03-31T13:17:00Z")))
-        self.assertFalse(target_is_due(target, _dt("2026-03-30T12:17:00Z")))
+        self.assertTrue(target_is_due(target, _dt("2026-03-30T12:17:00Z")))
+        self.assertTrue(target_is_due(target, _dt("2026-03-30T14:17:00Z")))
 
-    def test_daily_target_due_each_day_at_matching_hour(self):
-        target = _target(cadence="daily", preferred_weekday_utc=None, preferred_hour_utc=13)
+    def test_daily_target_due_each_day_regardless_of_hour(self):
+        target = _target(cadence="daily", preferred_weekday_utc=None)
         self.assertTrue(target_is_due(target, _dt("2026-03-30T13:17:00Z")))
         self.assertTrue(target_is_due(target, _dt("2026-03-31T13:17:00Z")))
-        self.assertFalse(target_is_due(target, _dt("2026-03-31T11:17:00Z")))
+        self.assertTrue(target_is_due(target, _dt("2026-03-31T11:17:00Z")))
 
 
 def _dt(value: str) -> datetime:

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -48,7 +48,6 @@ TARGET = TargetRepo(
     issue_title_template="{short_name} report for {report_date}",
     cadence="weekly",
     preferred_weekday_utc=0,
-    preferred_hour_utc=13,
     extra_prompt="",
     agent_login_substrings=("dragon-ai-agent", "claude", "codex"),
     agent_text_patterns=("@dragon-ai-agent", "claude code"),


### PR DESCRIPTION
## Summary
- remove the internal exact-hour repo selector and let GitHub cron provide the clock
- keep weekday staggering for weekly targets
- cap watcher matrix concurrency to 2 so runs stay bounded

## Validation
- python3 -m unittest discover -s tests -p 'test_*.py'\n- python3 scripts/select_targets.py --config config/targets.json --event-name schedule --now-utc 2026-04-20T14:05:00Z\n- python3 scripts/select_targets.py --config config/targets.json --event-name schedule --now-utc 2026-04-22T14:36:00Z\n- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/scan-watched-repos.yml"); YAML.load_file(".github/workflows/review-agentic-setup.yml"); YAML.load_file(".github/workflows/validate.yml"); puts "workflow yaml ok"'