### PR TITLE
Fix watcher PR coverage in recent activity scan

### DIFF
--- a/src/agent_watcher/github_api.py
+++ b/src/agent_watcher/github_api.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import json
+from datetime import datetime, timezone
 from typing import Any
 from urllib.error import HTTPError
 from urllib.parse import quote
@@ -23,25 +24,11 @@ class GitHubClient:
         since: str,
         max_items: int,
     ) -> list[dict[str, Any]]:
-        items: list[dict[str, Any]] = []
-        page = 1
-
-        while len(items) < max_items:
-            payload = self._request_json(
-                "GET",
-                f"/repos/{repo}/issues?state=all&sort=updated&direction=desc&since={quote(since)}&per_page=100&page={page}",
-            )
-            if not payload:
-                break
-
-            for item in payload:
-                items.append(item)
-                if len(items) >= max_items:
-                    break
-
-            page += 1
-
-        return items
+        recent_issues = self._list_recent_issues(repo, since=since, limit=max_items)
+        recent_prs = self._list_recent_pull_requests(repo, since=since, limit=max_items)
+        combined = recent_issues + recent_prs
+        combined.sort(key=lambda item: _parse_datetime(item["updated_at"]), reverse=True)
+        return combined[:max_items]
 
     def list_issue_comments(
         self,
@@ -189,6 +176,80 @@ class GitHubClient:
             data={"body": body},
         )
 
+    def _list_recent_issues(
+        self,
+        repo: str,
+        *,
+        since: str,
+        limit: int,
+    ) -> list[dict[str, Any]]:
+        items: list[dict[str, Any]] = []
+        page = 1
+        since_dt = _parse_datetime(since)
+
+        while len(items) < limit:
+            payload = self._request_json(
+                "GET",
+                f"/repos/{repo}/issues?state=all&sort=updated&direction=desc&since={quote(since)}&per_page=100&page={page}",
+            )
+            if not payload:
+                break
+
+            for item in payload:
+                if item.get("pull_request"):
+                    continue
+                if _parse_datetime(item["updated_at"]) < since_dt:
+                    return items
+                items.append(item)
+                if len(items) >= limit:
+                    break
+
+            if len(payload) < 100:
+                break
+            page += 1
+
+        return items
+
+    def _list_recent_pull_requests(
+        self,
+        repo: str,
+        *,
+        since: str,
+        limit: int,
+    ) -> list[dict[str, Any]]:
+        items: list[dict[str, Any]] = []
+        page = 1
+        since_dt = _parse_datetime(since)
+
+        while len(items) < limit:
+            payload = self._request_json(
+                "GET",
+                f"/repos/{repo}/pulls?state=all&sort=updated&direction=desc&per_page=100&page={page}",
+            )
+            if not payload:
+                break
+
+            for item in payload:
+                if _parse_datetime(item["updated_at"]) < since_dt:
+                    return items
+                normalized = dict(item)
+                normalized.setdefault(
+                    "pull_request",
+                    {
+                        "url": item.get("url"),
+                        "html_url": item.get("html_url"),
+                    },
+                )
+                items.append(normalized)
+                if len(items) >= limit:
+                    break
+
+            if len(payload) < 100:
+                break
+            page += 1
+
+        return items
+
     def _request_json(
         self,
         method: str,
@@ -220,3 +281,7 @@ class GitHubClient:
             raise RuntimeError(
                 f"GitHub API {method} {url} failed with {exc.code}: {detail[:400]}"
             ) from exc
+
+
+def _parse_datetime(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest import TestCase
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from agent_watcher.github_api import GitHubClient
+
+
+class FakeGitHubClient(GitHubClient):
+    def __init__(self, issue_pages, pull_pages):
+        super().__init__(token=None)
+        self.issue_pages = issue_pages
+        self.pull_pages = pull_pages
+
+    def _request_json(self, method: str, path_or_url: str, *, data=None):
+        if "/issues?" in path_or_url:
+            page = _page_number(path_or_url)
+            return self.issue_pages.get(page, [])
+        if "/pulls?" in path_or_url:
+            page = _page_number(path_or_url)
+            return self.pull_pages.get(page, [])
+        raise AssertionError(f"Unexpected request: {path_or_url}")
+
+
+class GitHubApiTests(TestCase):
+    def test_recent_items_merge_issue_and_pull_feeds(self):
+        client = FakeGitHubClient(
+            issue_pages={
+                1: [
+                    _issue(31912, "2026-04-18T15:38:00Z"),
+                    _issue(19185, "2026-04-17T07:59:00Z"),
+                    _issue(31869, "2026-04-16T01:04:00Z"),
+                ]
+            },
+            pull_pages={
+                1: [
+                    _pull(31920, "2026-04-18T12:00:00Z", author="cmungall"),
+                    _pull(31911, "2026-04-17T08:22:37Z", author="dragon-ai-agent"),
+                    _pull(31907, "2026-04-16T00:26:18Z", author="dragon-ai-agent"),
+                    _pull(31801, "2026-04-01T11:12:00Z", author="dragon-ai-agent"),
+                ]
+            },
+        )
+
+        items = client.list_recent_issues_and_prs(
+            "geneontology/go-ontology",
+            since="2026-04-05T22:51:16Z",
+            max_items=5,
+        )
+
+        self.assertEqual(
+            [(item["number"], bool(item.get("pull_request"))) for item in items],
+            [
+                (31912, False),
+                (31920, True),
+                (31911, True),
+                (19185, False),
+                (31869, False),
+            ],
+        )
+
+
+def _page_number(path_or_url: str) -> int:
+    marker = "page="
+    return int(path_or_url.rsplit(marker, 1)[1].split("&", 1)[0])
+
+
+def _issue(number: int, updated_at: str) -> dict:
+    return {
+        "number": number,
+        "title": f"Issue {number}",
+        "html_url": f"https://github.com/example/repo/issues/{number}",
+        "state": "open",
+        "created_at": updated_at,
+        "updated_at": updated_at,
+        "body": "",
+        "user": {"login": "curator"},
+    }
+
+
+def _pull(number: int, updated_at: str, *, author: str) -> dict:
+    return {
+        "number": number,
+        "title": f"PR {number}",
+        "html_url": f"https://github.com/example/repo/pull/{number}",
+        "url": f"https://api.github.com/repos/example/repo/pulls/{number}",
+        "state": "closed",
+        "created_at": updated_at,
+        "updated_at": updated_at,
+        "body": "",
+        "user": {"login": author},
+    }


### PR DESCRIPTION
## Summary
- fetch recent issues and recent pull requests separately before merging the scan window
- stop depending on the mixed `/issues` feed to surface recent PRs in busy repos
- add a regression test covering the GO-style case where a merged agent PR must appear in the recent sample

## Validation
- python3 -m unittest discover -s tests -p 'test_*.py'\n- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/scan-watched-repos.yml"); YAML.load_file(".github/workflows/review-agentic-setup.yml"); YAML.load_file(".github/workflows/validate.yml"); puts "workflow yaml ok"'\n- WATCHER_SOURCE_TOKEN="$CBORG_CODE_GITHUB_TOKEN" python3 scripts/run_watch.py --config config/targets.json --target geneontology/go-ontology --output-dir build/fix-pr-coverage --dry-run\n\n## GO check\nThe local rerun now includes PR #31911 as a merged agent-authored PR and reports `merged_prs=2` for the same 2026-04-19 GO window.